### PR TITLE
remove `successAction`

### DIFF
--- a/lib/subprotocols/payRequest.js
+++ b/lib/subprotocols/payRequest.js
@@ -107,7 +107,6 @@ module.exports = {
 					this.emit('payRequest:action:processed', { secret, params, result });
 					return {
 						pr: result.invoice,
-						successAction: null,
 						routes: [],
 					};
 				}).catch(error => {


### PR DESCRIPTION
It being `null` breaks some wallets, better just not send it.