### PR TITLE
decide action based in amount versus parameter q

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -368,7 +368,8 @@ Server.prototype.middleware = function() {
 				return next(new HttpError('Missing secret', 400));
 			}
 			const hash = createHash(secret);
-			const method = req.query.q ? 'info' : 'action';
+			req.params.k1 = req.query.q
+			const method = req.query.amount ? 'action' : 'info';
 			this.emit('request:received', { hash, method, req });
 			this.fetchUrl(hash).then(fetchedUrl => {
 				if (!fetchedUrl) {


### PR DESCRIPTION
I realized that BlueWallet after sending money with a Lightning Address using  /.well-known/lnurlp/username, then it's using the format /ln/lnurl?q=secret&amount=50000&nonce=3768d021ba7faa&comment=comment

Don't take my proposal as final solution as I am a beginner developer and I didn't test it thoroughly, but at least you can use to think about it. 

If it's useful, send a few satoshis to marcos@madastur.com, not looking for money, but for some activity in my node and code ;-) 

Marcos