### PR TITLE
feat: add optional param k1 for lnurl

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -599,22 +599,22 @@ Server.prototype.prepareStore = function(options) {
 	return new Store(config);
 };
 
-Server.prototype.generateNewUrl = function(tag, params, options) {
-	return this.generateSecret().then(secret => {
-		return this.createUrl(secret, tag, params, options).then(result => {
-			let query;
-			switch (tag) {
-				case 'login':
-					query = { tag, k1: secret };
-					break;
-				default:
-					query = { q: secret };
-					break;
-			}
-			const newUrl = this.getCallbackUrl(query);
-			const encoded = encode(newUrl);
-			return { encoded, secret, url: newUrl };
-		});
+Server.prototype.generateNewUrl = async function(tag, params, options) {
+	const secret = params.k1 === undefined? await this.generateSecret() : params.k1;
+
+	return this.createUrl(secret, tag, params, options).then(result => {
+		let query;
+		switch (tag) {
+			case 'login':
+				query = { tag, k1: secret };
+				break;
+			default:
+				query = { q: secret };
+				break;
+		}
+		const newUrl = this.getCallbackUrl(query);
+		const encoded = encode(newUrl);
+		return { encoded, secret, url: newUrl };
 	});
 };
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -599,22 +599,17 @@ Server.prototype.prepareStore = function(options) {
 	return new Store(config);
 };
 
-Server.prototype.generateNewUrl = async function(tag, params, options) {
-	const secret = params.k1 === undefined? await this.generateSecret() : params.k1;
-
-	return this.createUrl(secret, tag, params, options).then(result => {
-		let query;
-		switch (tag) {
-			case 'login':
-				query = { tag, k1: secret };
-				break;
-			default:
-				query = { q: secret };
-				break;
-		}
-		const newUrl = this.getCallbackUrl(query);
-		const encoded = encode(newUrl);
-		return { encoded, secret, url: newUrl };
+Server.prototype.generateNewUrl = function(tag, params, options) {
+	return Promise.resolve().then(() => {
+		params = params || {};
+		return typeof params.k1 !== 'undefined' ? params.k1 : this.generateSecret();
+	}).then(secret => {
+		return this.createUrl(secret, tag, params, options).then(result => {
+			const query = tag === 'login' ? { tag, k1: secret } : { q: secret};
+			const newUrl = this.getCallbackUrl(query);
+			const encoded = encode(newUrl);
+			return { encoded, secret, url: newUrl };
+		});
 	});
 };
 

--- a/test/unit/lib/Server/generateNewUrl.js
+++ b/test/unit/lib/Server/generateNewUrl.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+const querystring = require('querystring');
+const url = require('url');
+const { validParams } = require('../../../fixtures');
+
+describe('generateNewUrl(tag, params[, options])', function() {
+
+	let server;
+	before(function() {
+		server = this.helpers.createServer({
+			listen: false,
+			lightning: null,
+		});
+		return server.onReady();
+	});
+
+	after(function() {
+		if (server) return server.close();
+	});
+
+	it('withdrawRequest', function() {
+		const tag = 'withdrawRequest';
+		const params = Object.assign({}, validParams['create'][tag]);
+		return server.generateNewUrl(tag, params).then(result => {
+			assert.ok(result && typeof result === 'object');
+			assert.ok(result.encoded);
+			assert.ok(result.secret);
+			assert.ok(result.url);
+			const parsed = url.parse(result.url);
+			const query = querystring.parse(parsed.query);
+			assert.strictEqual(query.q, result.secret);
+			return server.generateNewUrl(tag, params).then(result2 => {
+				assert.notStrictEqual(result2.secret, result.secret);
+			});
+		});
+	});
+
+	it('pre-defined secret (k1)', function() {
+		const tag = 'withdrawRequest';
+		const params = Object.assign({}, validParams['create'][tag], {
+			k1: 'pre-defined 12345',
+		});
+		return server.generateNewUrl(tag, params).then(result => {
+			assert.ok(result && typeof result === 'object');
+			assert.ok(result.encoded);
+			assert.ok(result.secret);
+			assert.ok(result.url);
+			const parsed = url.parse(result.url);
+			const query = querystring.parse(parsed.query);
+			assert.strictEqual(query.q, result.secret);
+			assert.strictEqual(result.secret, params.k1);
+		});
+	});
+});


### PR DESCRIPTION
As stated, in [LUD03](https://github.com/lnurl/luds/blob/luds/03.md), k1 value can be either random or non-random string.
LN service needs more option to identify the user's LN WALLET when using the callback URL(rather than generating random hash on behalf)