### PR TITLE
fix: do not convert private to boolean before passing it to ln.openChannel

### DIFF
--- a/lib/subprotocols/channelRequest.js
+++ b/lib/subprotocols/channelRequest.js
@@ -44,7 +44,6 @@ module.exports = {
 			let { remoteid, localAmt, pushAmt, private } = params;
 			assert.ok(remoteid, new HttpError('Missing required parameter: "remoteid"', 400));
 			assert.ok(typeof private !== 'undefined', new HttpError('Missing required parameter: "private"', 400));
-			private = parseInt(private) === 1;
 			return this.executeHook('channelRequest:action', secret, params).then(() => {
 				// Tell the LN backend to open a new channel.
 				return this.ln.openChannel(remoteid, localAmt, pushAmt, private).then(result => {


### PR DESCRIPTION
ln.openChannel accepts private param as integer. But it is converted to boolean in this function